### PR TITLE
gossip: refactor message flow for gossip sync

### DIFF
--- a/examples/gossip/index.ts
+++ b/examples/gossip/index.ts
@@ -1,5 +1,5 @@
 import { ConsoleTransport, Logger, LogLevel } from "@node-lightning/logger";
-import { BitField, ChannelAnnouncementMessage } from "@node-lightning/wire";
+import { ChannelAnnouncementMessage } from "@node-lightning/wire";
 import { ChannelUpdateMessage } from "@node-lightning/wire";
 import { NodeAnnouncementMessage } from "@node-lightning/wire";
 import { ExtendedChannelAnnouncementMessage } from "@node-lightning/wire";
@@ -7,6 +7,7 @@ import { Peer } from "@node-lightning/wire";
 import { GossipMemoryStore } from "@node-lightning/wire";
 import { GossipManager } from "@node-lightning/wire";
 import { InitFeatureFlags } from "@node-lightning/wire";
+import { BitField } from "@node-lightning/core";
 
 // tslint:disable-next-line: no-var-requires
 const config = require("../config.json");

--- a/examples/gossip/package.json
+++ b/examples/gossip/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@node-lightning/bufio": "file:../../packages/bufio",
     "@node-lightning/chainmon": "file:../../packages/chainmon",
+    "@node-lightning/core": "file:../../packages/core",
     "@node-lightning/crypto": "file:../../packages/crypto",
     "@node-lightning/logger": "file:../../packages/logger",
     "@node-lightning/noise": "file:../../packages/noise",

--- a/examples/graph/index.ts
+++ b/examples/graph/index.ts
@@ -6,7 +6,7 @@ import { GraphManager } from "@node-lightning/graph";
 import { GraphError } from "@node-lightning/graph";
 import { LndSerializer } from "@node-lightning/graph";
 import { ConsoleTransport, Logger, LogLevel } from "@node-lightning/logger";
-import { BitField } from "@node-lightning/wire";
+import { BitField } from "@node-lightning/core";
 import { ExtendedChannelAnnouncementMessage } from "@node-lightning/wire";
 import { Peer } from "@node-lightning/wire";
 import { GossipMemoryStore } from "@node-lightning/wire";

--- a/examples/graph/package.json
+++ b/examples/graph/package.json
@@ -13,6 +13,7 @@
     "@node-lightning/bitcoind": "file:../../packages/bitcoind",
     "@node-lightning/bufio": "file:../../packages/bufio",
     "@node-lightning/chainmon": "file:../../packages/chainmon",
+    "@node-lightning/core": "file:../../packages/core",
     "@node-lightning/crypto": "file:../../packages/crypto",
     "@node-lightning/gossip-rocksdb": "file:../../packages/gossip-rocksdb",
     "@node-lightning/graph": "file:../../packages/graph",

--- a/examples/peer/index.ts
+++ b/examples/peer/index.ts
@@ -1,5 +1,5 @@
 import { ConsoleTransport, Logger, LogLevel } from "@node-lightning/logger";
-import { BitField } from "@node-lightning/wire";
+import { BitField } from "@node-lightning/core";
 import { QueryChannelRangeMessage } from "@node-lightning/wire";
 import { Peer } from "@node-lightning/wire";
 import { InitFeatureFlags } from "@node-lightning/wire/dist/flags/InitFeatureFlags";

--- a/examples/peer/package.json
+++ b/examples/peer/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@node-lightning/bufio": "file:../../packages/bufio",
     "@node-lightning/chainmon": "file:../../packages/chainmon",
+    "@node-lightning/core": "file:../../packages/core",
     "@node-lightning/crypto": "file:../../packages/crypto",
     "@node-lightning/logger": "file:../../packages/logger",
     "@node-lightning/noise": "file:../../packages/noise",

--- a/packages/wire/__tests__/gossip/GossipQueriesSync.spec.ts
+++ b/packages/wire/__tests__/gossip/GossipQueriesSync.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ShortChannelId } from "@node-lightning/core";
 import { ILogger } from "@node-lightning/logger";
 import { expect } from "chai";
@@ -54,7 +55,7 @@ describe("GossipQueriesSync", () => {
         // for the channels query result along with
         const replyChannelsMsg = new ReplyShortChannelIdsEndMessage();
         replyChannelsMsg.complete = true;
-        peer.emit("message", replyChannelsMsg);
+        sut.handleWireMessage(replyChannelsMsg);
         await wait(0); // wait for promise to tick
 
         // After this reply, we are just waiting for the final messages to
@@ -132,7 +133,7 @@ describe("GossipQueriesSync", () => {
         // for the channels query result along with
         const replyChannelsMsg = new ReplyShortChannelIdsEndMessage();
         replyChannelsMsg.complete = false;
-        peer.emit("message", replyChannelsMsg);
+        sut.handleWireMessage(replyChannelsMsg);
 
         // Wait for the promise to fail
         return promise.catch((err: GossipError) => {

--- a/packages/wire/__tests__/gossip/GossipQueriesSync.spec.ts
+++ b/packages/wire/__tests__/gossip/GossipQueriesSync.spec.ts
@@ -44,7 +44,7 @@ describe("GossipQueriesSync", () => {
         replyRangeMsg.firstBlocknum = 0;
         replyRangeMsg.numberOfBlocks = 0xffffffff;
         replyRangeMsg.shortChannelIds.push(new ShortChannelId(1, 1, 1));
-        peer.emit("message", replyRangeMsg);
+        sut.handleWireMessage(replyRangeMsg);
         await wait(0); // wait for promise to tick
 
         // After the reply, we will validate that the
@@ -89,7 +89,7 @@ describe("GossipQueriesSync", () => {
         replyRangeMsg.fullInformation = false;
         replyRangeMsg.firstBlocknum = 0;
         replyRangeMsg.numberOfBlocks = 0xffffffff;
-        peer.emit("message", replyRangeMsg);
+        sut.handleWireMessage(replyRangeMsg);
 
         // Wait for the promise to fail
         return promise.catch((err: GossipError) => {
@@ -122,7 +122,7 @@ describe("GossipQueriesSync", () => {
         replyRangeMsg.firstBlocknum = 0;
         replyRangeMsg.numberOfBlocks = 0xffffffff;
         replyRangeMsg.shortChannelIds.push(new ShortChannelId(1, 1, 1));
-        peer.emit("message", replyRangeMsg);
+        sut.handleWireMessage(replyRangeMsg);
         await wait(0); // wait for promise to tick
 
         // After the reply, we will validate that the

--- a/packages/wire/__tests__/gossip/GossipSyncWatcher.spec.ts
+++ b/packages/wire/__tests__/gossip/GossipSyncWatcher.spec.ts
@@ -1,18 +1,17 @@
 import { ILogger } from "@node-lightning/logger";
 import { expect } from "chai";
 import { GossipSyncWatcher } from "../../lib/gossip/GossipSyncWatcher";
-import { createFakeLogger, createFakePeer, wait } from "../_test-utils";
+import { ChannelAnnouncementMessage } from "../../lib/messages/ChannelAnnouncementMessage";
+import { createFakeLogger, wait } from "../_test-utils";
 
 describe("GossipSyncWatcher", () => {
-    let peer: any;
     let logger: ILogger;
     let sut: GossipSyncWatcher;
     let promise: Promise<void>;
 
     beforeEach(() => {
-        peer = createFakePeer();
         logger = createFakeLogger();
-        sut = new GossipSyncWatcher(peer, logger);
+        sut = new GossipSyncWatcher(logger);
         sut.completeAfterMs = 50;
     });
 
@@ -24,13 +23,13 @@ describe("GossipSyncWatcher", () => {
         promise = sut.watch();
         Promise.resolve()
             .then(() => wait(25))
-            .then(() => peer.emit("message"))
+            .then(() => sut.onGossipMessage(new ChannelAnnouncementMessage()))
             .then(() => wait(25))
-            .then(() => peer.emit("message"))
+            .then(() => sut.onGossipMessage(new ChannelAnnouncementMessage()))
             .then(() => wait(25))
-            .then(() => peer.emit("message"))
+            .then(() => sut.onGossipMessage(new ChannelAnnouncementMessage()))
             .then(() => wait(25))
-            .then(() => peer.emit("message"))
+            .then(() => sut.onGossipMessage(new ChannelAnnouncementMessage()))
             .then(() => wait(200))
             .then(() => promise)
             .then(() => {

--- a/packages/wire/lib/gossip/GossipPeer.ts
+++ b/packages/wire/lib/gossip/GossipPeer.ts
@@ -78,7 +78,10 @@ export class GossipPeer extends EventEmitter implements IPeer {
         if (this.gossipQueries) {
             const chainHash = this.peer.localChains[0];
             const synchronizer = new GossipQueriesSync(chainHash, this, this.logger);
+            const msgHandler = (msg: IWireMessage) => synchronizer.handleWireMessage(msg);
+            this.on("message", msgHandler);
             await synchronizer.queryRange(firstBlock, numBlocks);
+            this.off("message", msgHandler);
             return true;
         }
         return false;

--- a/packages/wire/lib/gossip/GossipQueriesSync.ts
+++ b/packages/wire/lib/gossip/GossipQueriesSync.ts
@@ -1,6 +1,7 @@
 import { ILogger } from "@node-lightning/logger";
 import { IWireMessage } from "../messages/IWireMessage";
 import { ReplyChannelRangeMessage } from "../messages/ReplyChannelRangeMessage";
+import { ReplyShortChannelIdsEndMessage } from "../messages/ReplyShortChannelIdsEndMessage";
 import { ChannelRangeQuery } from "./ChannelRangeQuery";
 import { ChannelsQuery } from "./ChannelsQuery";
 import { GossipPeer } from "./GossipPeer";
@@ -62,6 +63,8 @@ export class GossipQueriesSync {
         if (msg instanceof ReplyChannelRangeMessage) {
             this._rangeQuery.handleReplyChannelRange(msg);
             return;
+        } else if (msg instanceof ReplyShortChannelIdsEndMessage) {
+            this._channelsQuery.handleReplyShortChannelIdsEnd(msg);
         }
     }
 }

--- a/packages/wire/lib/gossip/GossipQueriesSync.ts
+++ b/packages/wire/lib/gossip/GossipQueriesSync.ts
@@ -1,4 +1,6 @@
 import { ILogger } from "@node-lightning/logger";
+import { IWireMessage } from "../messages/IWireMessage";
+import { ReplyChannelRangeMessage } from "../messages/ReplyChannelRangeMessage";
 import { ChannelRangeQuery } from "./ChannelRangeQuery";
 import { ChannelsQuery } from "./ChannelsQuery";
 import { GossipPeer } from "./GossipPeer";
@@ -53,6 +55,13 @@ export class GossipQueriesSync {
             this._state = GossipQueriesSyncState.Failed;
             this._error = ex;
             throw ex;
+        }
+    }
+
+    public handleWireMessage(msg: IWireMessage): void {
+        if (msg instanceof ReplyChannelRangeMessage) {
+            this._rangeQuery.handleReplyChannelRange(msg);
+            return;
         }
     }
 }

--- a/packages/wire/lib/gossip/GossipQueriesSync.ts
+++ b/packages/wire/lib/gossip/GossipQueriesSync.ts
@@ -1,8 +1,8 @@
 import { ILogger } from "@node-lightning/logger";
-import { NodeAnnouncementMessage } from "../messages/NodeAnnouncementMessage";
 import { ChannelAnnouncementMessage } from "../messages/ChannelAnnouncementMessage";
 import { ChannelUpdateMessage } from "../messages/ChannelUpdateMessage";
 import { IWireMessage } from "../messages/IWireMessage";
+import { NodeAnnouncementMessage } from "../messages/NodeAnnouncementMessage";
 import { ReplyChannelRangeMessage } from "../messages/ReplyChannelRangeMessage";
 import { ReplyShortChannelIdsEndMessage } from "../messages/ReplyShortChannelIdsEndMessage";
 import { IMessageSender } from "../Peer";


### PR DESCRIPTION
Removes direct references to the peer.on("message") events in favor of code orchestration. This is prep work for #144. 