### PR TITLE
Closing Signed Message Update wire

### DIFF
--- a/packages/wire/__tests__/messages/ClosingSignedMessage.spec.ts
+++ b/packages/wire/__tests__/messages/ClosingSignedMessage.spec.ts
@@ -9,8 +9,8 @@ describe("ClosingSignedMessage", () => {
                 "0027"+ // type
                 "0000000000000000000000000000000000000000000000000000000000000000" +    // Channel ID
                 "0000000000030d40" + // feeSatoshi
-            "22222222222222222222222222222222222222222222222222222222222222223333333333333333333333333333333333333333333333333333333333333333" //signature
-            , "hex"); // prettier-ignore
+                "22222222222222222222222222222222222222222222222222222222222222223333333333333333333333333333333333333333333333333333333333333333" //signature
+                , "hex"); // prettier-ignore
             const result = ClosingSignedMessage.deserialize(input);
             expect(result.type).to.equal(39);
             expect(result.channelId.toString()).to.equal("0000000000000000000000000000000000000000000000000000000000000000"); // prettier-ignore

--- a/packages/wire/__tests__/messages/ClosingSignedMessage.spec.ts
+++ b/packages/wire/__tests__/messages/ClosingSignedMessage.spec.ts
@@ -1,0 +1,35 @@
+import { ChannelId } from "@node-lightning/core";
+import { expect } from "chai";
+import { ClosingSignedMessage } from "../../lib/messages/ClosingSignedMessage";
+
+describe("ClosingSignedMessage", () => {
+    describe(".deserialize", () => {
+        it("should deserialize without error", () => {
+            const input = Buffer.from(
+                "0027"+ // type
+                "0000000000000000000000000000000000000000000000000000000000000000" +    // Channel ID
+                "0000000000030d40" + // feeSatoshi
+            "22222222222222222222222222222222222222222222222222222222222222223333333333333333333333333333333333333333333333333333333333333333" //signature
+            , "hex"); // prettier-ignore
+            const result = ClosingSignedMessage.deserialize(input);
+            expect(result.type).to.equal(39);
+            expect(result.channelId.toString()).to.equal("0000000000000000000000000000000000000000000000000000000000000000"); // prettier-ignore
+            expect(result.feeSatoshis).to.equal(BigInt(200000));
+            expect(result.signature.toString("hex")).to.equal("22222222222222222222222222222222222222222222222222222222222222223333333333333333333333333333333333333333333333333333333333333333"); // prettier-ignore
+        });
+    });
+
+    describe(".serialize", () => {
+        it("should serialize a message", () => {
+            const instance = new ClosingSignedMessage();
+            instance.channelId = new ChannelId(Buffer.from("0000000000000000000000000000000000000000000000000000000000000000", "hex")); // prettier-ignore
+            instance.feeSatoshis = BigInt(200000);
+            instance.signature = Buffer.from("22222222222222222222222222222222222222222222222222222222222222223333333333333333333333333333333333333333333333333333333333333333", "hex"); // prettier-ignore
+
+            const result = instance.serialize();
+            expect(result.toString("hex")).to.equal(
+                "002700000000000000000000000000000000000000000000000000000000000000000000000000030d4022222222222222222222222222222222222222222222222222222222222222223333333333333333333333333333333333333333333333333333333333333333",
+            );
+        });
+    });
+});

--- a/packages/wire/lib/MessageType.ts
+++ b/packages/wire/lib/MessageType.ts
@@ -14,6 +14,8 @@ export enum MessageType {
     FundingCreated = 34,
     FundingSigned = 35,
     FundingLocked = 36,
+    CloseChannel = 38,
+    ClosingSigned = 39,
 
     // Commitment (128-255)
     //

--- a/packages/wire/lib/messages/ClosingSignedMessage.ts
+++ b/packages/wire/lib/messages/ClosingSignedMessage.ts
@@ -9,8 +9,11 @@ import { IWireMessage } from "./IWireMessage";
  * is fair, and signs the closing transaction with the scriptpubkey fields from
  * the shutdown messages (along with its chosen fee) and sends the signature.
  * The other node then replies similarly, using a fee it thinks is fair.
- * This exchange continues using the channelID until both agree on the same
- * fee or when one side fails the channel.
+ * One of the benefits of mutual close is that the fee rate can be negotiated
+ * down from the existing fee rate(which is generally expensive) to a more reasonable one.
+ * In order for fee rate to converge, it has to be strictly between the last proposed
+ * and the counterparty's last proposed value. This exchange continues using the
+ * channelID until both agree on the same fee or when one side fails the channel.
  */
 export class ClosingSignedMessage implements IWireMessage {
     public static type: MessageType = MessageType.ClosingSigned;
@@ -43,9 +46,11 @@ export class ClosingSignedMessage implements IWireMessage {
     public channelId: ChannelId;
 
     /**
-     * Expected value for fee_satoshis could vary how fast either side wants the transaction
-     * to be included in the block. So changes are made accordingly on both ends and communicated
-     * between the channel untill both of them comes to an agreement or when one side fails the
+     * Expected value for fee_satoshis could vary how fee rate negotiations happens between the
+     * two nodes.Assuming initially both nodes have different fee estimates, in every iteration
+     * they should ensure fee rate is strictly between their last proposed and the counterparty's
+     * last proposed value. Hence changes are made accordingly on both ends and communicated
+     * between the channel until both of them comes to an agreement or when one side fails the
      * channel.
      */
     public feeSatoshis: bigint;

--- a/packages/wire/lib/messages/ClosingSignedMessage.ts
+++ b/packages/wire/lib/messages/ClosingSignedMessage.ts
@@ -1,0 +1,61 @@
+import { BufferReader, BufferWriter } from "@node-lightning/bufio";
+import { ChannelId } from "@node-lightning/core";
+import { MessageType } from "../MessageType";
+import { IWireMessage } from "./IWireMessage";
+
+
+/**
+ */
+export class ClosingSignedMessage implements IWireMessage {
+    public static type: MessageType = MessageType.ClosingSigned;
+
+    /**
+     * Deserializes the funding_signed message
+     * @param buf
+     * @returns
+     */
+    public static deserialize(buf: Buffer): ClosingSignedMessage {
+        const instance = new ClosingSignedMessage();
+        const reader = new BufferReader(buf);
+
+        reader.readUInt16BE(); // read type
+        instance.channelId = new ChannelId(reader.readBytes(32));
+        instance.feeSatoshis = reader.readUInt64BE();
+        instance.signature = reader.readBytes(64);
+
+        return instance;
+    }
+
+    /**
+     * The type for message. Closing_Signed = 39
+     */
+    public readonly type: MessageType = ClosingSignedMessage.type;
+
+    /**
+     * ChannelId generated from the funding transactions outpoint.
+     */
+    public channelId: ChannelId;
+
+    /**
+     * fee_satoshis is set according to its estimate of cost of inclusion in a block.
+     */
+    public feeSatoshis: bigint;
+
+    /**
+     * Sender signs the closing transaction with the scriptpubkey fields from the 
+     * shutdown messages (along with its chosen fee) and sends the signature;
+     */
+    public signature: Buffer;
+
+    /**
+     * Serializes the message into a Buffer
+     */
+    public serialize(): Buffer {
+        const writer = new BufferWriter();
+        writer.writeUInt16BE(this.type);
+        writer.writeBytes(this.channelId.toBuffer());
+        writer.writeUInt64BE(this.feeSatoshis);
+        writer.writeBytes(this.signature);
+        return writer.toBuffer();
+    }
+}

--- a/packages/wire/lib/messages/ClosingSignedMessage.ts
+++ b/packages/wire/lib/messages/ClosingSignedMessage.ts
@@ -3,14 +3,20 @@ import { ChannelId } from "@node-lightning/core";
 import { MessageType } from "../MessageType";
 import { IWireMessage } from "./IWireMessage";
 
-
 /**
+ * The `closing_signed` message is sent by the channel funder after
+ * the `shutdown_message`. The funder chooses a fee it thinks
+ * is fair, and signs the closing transaction with the scriptpubkey fields from
+ * the shutdown messages (along with its chosen fee) and sends the signature.
+ * The other node then replies similarly, using a fee it thinks is fair.
+ * This exchange continues using the channelID until both agree on the same
+ * fee or when one side fails the channel.
  */
 export class ClosingSignedMessage implements IWireMessage {
     public static type: MessageType = MessageType.ClosingSigned;
 
     /**
-     * Deserializes the funding_signed message
+     * Deserializes the closing_signed message
      * @param buf
      * @returns
      */
@@ -37,12 +43,15 @@ export class ClosingSignedMessage implements IWireMessage {
     public channelId: ChannelId;
 
     /**
-     * fee_satoshis is set according to its estimate of cost of inclusion in a block.
+     * Expected value for fee_satoshis could vary how fast either side wants the transaction
+     * to be included in the block. So changes are made accordingly on both ends and communicated
+     * between the channel untill both of them comes to an agreement or when one side fails the
+     * channel.
      */
     public feeSatoshis: bigint;
 
     /**
-     * Sender signs the closing transaction with the scriptpubkey fields from the 
+     * Sender signs the closing transaction with the scriptpubkey fields from the
      * shutdown messages (along with its chosen fee) and sends the signature;
      */
     public signature: Buffer;


### PR DESCRIPTION
### wire: create closing_signed message type #180
[BOLT #2](https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#closing-negotiation-closing_signed) 

- Parameters are defined according to `closing_signed` in [BOLT #2](https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#closing-negotiation-closing_signed) 
- Implementation is as per the standards given 
- UT attached for testing

@bmancini55 

