### PR TITLE
gossip: fixes channel sync for large results

### DIFF
--- a/packages/wire/lib/gossip/ChannelsQuery.ts
+++ b/packages/wire/lib/gossip/ChannelsQuery.ts
@@ -73,7 +73,9 @@ export class ChannelsQuery {
     public query(...scids: ShortChannelId[]): Promise<void> {
         return new Promise((resolve, reject) => {
             // enqueue the short ids
-            this._queue.push(...scids);
+            for (const scid of scids) {
+                this._queue.push(scid);
+            }
 
             // Ensure we are in the active state
             this._state = ChannelsQueryState.Active;


### PR DESCRIPTION
Closes #194

This fixes an error where a large number of scids (65k+) was resulting
in a RangeError: Maximum stack size exceeded. Upon investigation, the
ChannelQuery class takes an array of SCIDs and uses array.push(...scids).

Using push in this manner uses .apply under the covers. Apply uses the
stack.  Therefore the number of items you can push is limited by the
stack size.

The code was changed to use an iterator and push a single element at a
time.  An integration test was added to ensure there are not problems
in the future.