### PR TITLE
graph: add outpoint check on remove from graph

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/packages/graph/__tests__/graph-manager.spec.ts
+++ b/packages/graph/__tests__/graph-manager.spec.ts
@@ -185,10 +185,10 @@ describe("GraphManager", () => {
     });
 
     describe("close channel", () => {
-        function createMsg() {
+        function createMsg(scid: ShortChannelId, outpoint?: OutPoint) {
             const msg = new ExtendedChannelAnnouncementMessage();
             msg.shortChannelId = scid;
-            msg.outpoint = new OutPoint("1111111111111111111111111111111111111111111111111111111111111111", 0); // prettier-ignore
+            msg.outpoint = outpoint;
             msg.capacity = BigInt(1000);
             msg.nodeId1 = node1;
             msg.nodeId2 = node2;
@@ -197,10 +197,12 @@ describe("GraphManager", () => {
         }
 
         it("should remove a channel from the graph", () => {
-            gossipEmitter.emit("message", createMsg());
+            const outpoint = OutPoint.fromString("1111111111111111111111111111111111111111111111111111111111111111:0"); // prettier-ignore
+            gossipEmitter.emit("message", createMsg(new ShortChannelId(1, 1, 0), outpoint));
+            gossipEmitter.emit("message", createMsg(new ShortChannelId(1, 1, 1)));
+            expect(sut.graph.channels.size).to.equal(2);
+            sut.removeChannel(outpoint);
             expect(sut.graph.channels.size).to.equal(1);
-            sut.removeChannel(new OutPoint("1111111111111111111111111111111111111111111111111111111111111111", 0)); // prettier-ignore
-            expect(sut.graph.channels.size).to.equal(0);
         });
     });
 });

--- a/packages/graph/lib/graph-manager.ts
+++ b/packages/graph/lib/graph-manager.ts
@@ -44,7 +44,7 @@ export class GraphManager extends EventEmitter {
     public removeChannel(outpoint: OutPoint) {
         const outpointStr = outpoint.toString();
         for (const channel of this.graph.channels.values()) {
-            if (outpointStr === channel.channelPoint.toString()) {
+            if (outpointStr === channel?.channelPoint.toString()) {
                 this.graph.removeChannel(channel);
                 this.emit("channel_closed", channel);
                 return;


### PR DESCRIPTION
Modifies the GraphManager to perform a null check on the outpoint to
when a remove is performed.

Fixes #204