### PR TITLE
Fix typo in examples/peer/index.ts

### DIFF
--- a/examples/peer/index.ts
+++ b/examples/peer/index.ts
@@ -26,7 +26,7 @@ async function connectToPeer(peerInfo: { rpk: string; host: string; port: number
     localFeatures.set(InitFeatureFlags.optionDataLossProtectOptional);
     localFeatures.set(InitFeatureFlags.gossipQueriesOptional);
 
-    // constructs the peer and attaches a logger for tthe peer.
+    // constructs the peer and attaches a logger for the peer.
     const peer = new Peer(ls, localFeatures, [chainHash], logger);
     peer.on("open", () => logger.info("connecting"));
     peer.on("error", err => logger.error("%s", err.stack));


### PR DESCRIPTION
Typo fix. *It ain't much* meme.