### PR TITLE
bitcoin: make Value.add/sub fluent

### DIFF
--- a/packages/bitcoin/__tests__/Value.spec.ts
+++ b/packages/bitcoin/__tests__/Value.spec.ts
@@ -211,6 +211,12 @@ describe("Value", () => {
             a.add(b);
             expect(a.bitcoin).to.equal(1.00000001);
         });
+        it("is fluent", () => {
+            const sut = Value.zero()
+                .add(Value.fromSats(1000))
+                .add(Value.fromSats(400));
+            expect(sut.sats).to.equal(1400n);
+        });
     });
 
     describe(".sub()", () => {
@@ -225,6 +231,11 @@ describe("Value", () => {
             const a = Value.fromBitcoin(1);
             const b = Value.fromBitcoin(1.1);
             expect(() => a.sub(b)).to.throw("Value underflow");
+        });
+
+        it("is fluent", () => {
+            const sut = Value.fromSats(1000).sub(Value.fromSats(400));
+            expect(sut.sats).to.equal(600n);
         });
     });
 

--- a/packages/bitcoin/lib/Value.ts
+++ b/packages/bitcoin/lib/Value.ts
@@ -179,8 +179,9 @@ export class Value implements ICloneable<Value> {
      * existing value.
      * @param other
      */
-    public add(other: Value) {
+    public add(other: Value): this {
         this._picoSats += other._picoSats;
+        return this;
     }
 
     /**
@@ -189,10 +190,11 @@ export class Value implements ICloneable<Value> {
      * if subtraction results in a value that is less than zero.
      * @param other
      */
-    public sub(other: Value) {
+    public sub(other: Value): this {
         if (this._picoSats - other._picoSats < 0) {
             throw new BitcoinError(BitcoinErrorCode.ValueUnderflow);
         }
         this._picoSats -= other._picoSats;
+        return this;
     }
 }


### PR DESCRIPTION
This commit allows these two functions to return `self` so the methods can be used in a fluent style. This simple fix allows for easier math operations such as:

```typescript
const inputValue = Value.fromSats(10000);
const fees = Value.fromSats(255);
const outputValue = Value.zero().add(inputValue).sub(fees);
```

Closes #251 