### PR TITLE
bitcoin: craete `BlockHeader` type

### DIFF
--- a/packages/bitcoin/__tests__/Bits.spec.ts
+++ b/packages/bitcoin/__tests__/Bits.spec.ts
@@ -18,6 +18,22 @@ describe(Bits.name, () => {
         });
     });
 
+    describe(Bits.fromTarget.name, () => {
+        it("genesis block", () => {
+            const result = Bits.fromTarget(
+                26959535291011309493156476344723991336010898738574164086137773096960n,
+            );
+            expect(result.coefficient).to.equal(65535);
+            expect(result.exponent).to.equal(29);
+        });
+
+        it("block 757089", () => {
+            const result = Bits.fromTarget(859664032087861081904916640712713969859737457373741056n);
+            expect(result.coefficient).to.equal(588206);
+            expect(result.exponent).to.equal(23);
+        });
+    });
+
     describe(".target", () => {
         it("genesis block", () => {
             const sut = new Bits(65535, 29);
@@ -41,6 +57,18 @@ describe(Bits.name, () => {
         it("block 757089", () => {
             const sut = new Bits(588206, 23);
             expect(sut.difficulty).to.equal(31360548173144n);
+        });
+    });
+
+    describe(Bits.prototype.toBuffer.name, () => {
+        it("genesis block", () => {
+            const sut = new Bits(65535, 29);
+            expect(sut.toBuffer().toString("hex")).to.equal("ffff001d");
+        });
+
+        it("block 757089", () => {
+            const sut = new Bits(588206, 23);
+            expect(sut.toBuffer().toString("hex")).to.equal("aef90817");
         });
     });
 });

--- a/packages/bitcoin/__tests__/BlockHeader.spec.ts
+++ b/packages/bitcoin/__tests__/BlockHeader.spec.ts
@@ -1,0 +1,91 @@
+import { expect } from "chai";
+import { HashByteOrder } from "../lib";
+import { BlockHeader } from "../lib/BlockHeader";
+
+describe(BlockHeader.name, () => {
+    const buf_0 = Buffer.from(
+        "0100000000000000000000000000000000000000000000000000000000000000000000003BA3EDFD7A7B12B27AC72C3E67768F617FC81BC3888A51323A9FB8AA4B1E5E4A29AB5F49FFFF001D1DAC2B7C",
+        "hex",
+    );
+    const buf_482738 = Buffer.from(
+        "020000208ec39428b17323fa0ddec8e887b4a7c53b8c0a0a220cfd0000000000000000005b0750fce0a889502d40508d39576821155e9c9e3f5c3157f961db38fd8b25be1e77a759e93c0118a4ffd71d",
+        "hex",
+    );
+
+    describe(BlockHeader.fromBuffer.name, () => {
+        it("genesis block", () => {
+            const block = BlockHeader.fromBuffer(buf_0);
+            expect(block.version).to.equal(1);
+            expect(block.previousBlockHash.toString(HashByteOrder.RPC)).to.equal(
+                "0000000000000000000000000000000000000000000000000000000000000000",
+            );
+            expect(block.merkleRoot.toString(HashByteOrder.RPC)).to.equal(
+                "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+            );
+            expect(block.timestamp).to.equal(1231006505);
+            expect(block.bits.coefficient).to.equal(65535);
+            expect(block.bits.exponent).to.equal(29);
+            expect(block.bits.difficulty).to.equal(1n);
+            expect(block.nonce).to.equal(2083236893);
+        });
+
+        it("block 482738", () => {
+            const block = BlockHeader.fromBuffer(buf_482738);
+            expect(block.version).to.equal(536870914);
+            expect(block.previousBlockHash.toString(HashByteOrder.RPC)).to.equal(
+                "000000000000000000fd0c220a0a8c3bc5a7b487e8c8de0dfa2373b12894c38e",
+            );
+            expect(block.merkleRoot.toString(HashByteOrder.RPC)).to.equal(
+                "be258bfd38db61f957315c3f9e9c5e15216857398d50402d5089a8e0fc50075b",
+            );
+            expect(block.timestamp).to.equal(1504147230);
+            expect(block.bits.coefficient).to.equal(81129);
+            expect(block.bits.exponent).to.equal(24);
+            expect(block.bits.difficulty).to.equal(888171856257n);
+            expect(block.nonce).to.equal(500694948);
+            // expect(block.hash().toString(HashByteOrder.RPC)).to.equal("asdf");
+        });
+    });
+
+    describe(BlockHeader.prototype.hash.name, () => {
+        it("genesis block", () => {
+            const block = BlockHeader.fromBuffer(buf_0);
+            expect(block.hash().toString(HashByteOrder.RPC)).to.equal(
+                "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+            );
+        });
+
+        it("block 482738", () => {
+            const block = BlockHeader.fromBuffer(buf_482738);
+            expect(block.hash().toString(HashByteOrder.RPC)).to.equal(
+                "0000000000000000007e9e4c586439b0cdbe13b1370bdd9435d76a644d047523",
+            );
+        });
+    });
+
+    describe(BlockHeader.prototype.isBip9.name, () => {
+        it("genesis block", () => {
+            const block = BlockHeader.fromBuffer(buf_0);
+            expect(block.isBip9()).to.equal(false);
+        });
+
+        it("block 482738", () => {
+            const block = BlockHeader.fromBuffer(buf_482738);
+            expect(block.isBip9()).to.equal(true);
+        });
+    });
+
+    describe(BlockHeader.prototype.isBip9Feature.name, () => {
+        it("genesis block", () => {
+            const block = BlockHeader.fromBuffer(buf_0);
+            expect(block.isBip9Feature(1)).to.equal(false);
+        });
+
+        it("block 482738", () => {
+            const block = BlockHeader.fromBuffer(buf_482738);
+            expect(block.isBip9Feature(0)).to.equal(false);
+            expect(block.isBip9Feature(1)).to.equal(true);
+            expect(block.isBip9Feature(2)).to.equal(false);
+        });
+    });
+});

--- a/packages/bitcoin/lib/Bits.ts
+++ b/packages/bitcoin/lib/Bits.ts
@@ -1,4 +1,4 @@
-import { BufferReader } from "@node-lightning/bufio";
+import { bigToBufBE, BufferReader, BufferWriter } from "@node-lightning/bufio";
 
 /**
  * Bits encodes the proof-of-work necessary in this block. It contains
@@ -14,14 +14,63 @@ export class Bits {
      * @param buf
      * @returns
      */
-    public static fromBuffer(buf: Buffer) {
+    public static fromBuffer(buf: Buffer): Bits {
         const reader = new BufferReader(buf);
         const coefficient = reader.readUIntLE(3);
         const exponent = reader.readUInt8();
         return new Bits(coefficient, exponent);
     }
 
+    /**
+     * Converts a target into a `Bits` instance. This is the inverse of
+     * the `target` property on a `Bits` instance. The algorithm to
+     * convert a target is to write the number into a Buffer in
+     * big-endian. The required bytes is the exponent and the
+     * coefficient is the top three most bytes. If the topmost bit is
+     * set then we
+     * @param target
+     */
+    public static fromTarget(target: bigint): Bits {
+        let exponent: number;
+        let coefficient: number;
+
+        // Convert the number to BE bytes
+        const rawBytes = bigToBufBE(target);
+
+        // The target is always positive, therefore we need to prevent this from
+        // being treated as a negative number. If the first bit is a 1 (>=0x80),
+        // push a 0x00 as the first byte of the coefficient
+        if (rawBytes[0] > 0x7f) {
+            exponent = rawBytes.length + 1;
+            coefficient = (rawBytes[0] << 8) + rawBytes[1];
+        } else {
+            exponent = rawBytes.length;
+            coefficient = (rawBytes[0] << 16) + (rawBytes[1] << 8) + rawBytes[2];
+        }
+
+        return new Bits(coefficient, exponent);
+    }
+
+    /**
+     * Constructs a new `Bits` instance.
+     * @param coefficient
+     * @param exponent
+     */
     constructor(readonly coefficient: number, readonly exponent: number) {}
+
+    /**
+     * Serializes the bits to a Buffer in the format used for RPC block
+     * serialization. This means that hte lower three bytes are the
+     * coefficient little-endian and the upper byte is the exponent.
+     * One final piece of complexity is that if the coefficient is
+     * greater than 0x800000 then we pad it and
+     */
+    public toBuffer(): Buffer {
+        const writer = new BufferWriter(Buffer.alloc(4));
+        writer.writeUIntLE(this.coefficient, 3);
+        writer.writeUInt8(this.exponent);
+        return writer.toBuffer();
+    }
 
     /**
      * Calculates the proof-of-work requirements from the bits. Target

--- a/packages/bitcoin/lib/BlockHeader.ts
+++ b/packages/bitcoin/lib/BlockHeader.ts
@@ -1,0 +1,174 @@
+import { BufferReader, BufferWriter } from "@node-lightning/bufio";
+import { hash256 } from "@node-lightning/crypto";
+import { Bits } from "./Bits";
+import { HashByteOrder } from "./HashByteOrder";
+import { HashValue } from "./HashValue";
+
+/**
+ * This class represents a Bitcoin block header which is a Block less the
+ * transaction information.
+ */
+export class BlockHeader {
+    public static ByteSize = 80;
+
+    /**
+     * Parses a block header. The previous block and merkle root are
+     * transmitted in little-endian format. For example:
+     *
+     * ```
+     * 02000020 - version, 4-byte LE
+     * 8ec39428b17323fa0ddec8e887b4a7c53b8c0a0a220cfd000000000000000000 - previous block, 32-bytes, internal order (LE)
+     * 5b0750fce0a889502d40508d39576821155e9c9e3f5c3157f961db38fd8b25be - merkle root, 32-bytes, internal order (LE)
+     * 1e77a759 - timestamp, 4-byte LE
+     * e93c0118 - bits, 4-byte LE
+     * a4ffd71d - nonce, 4-byte LE
+     * ```
+     * @example
+     * ```typescript
+     * const buffer = Buffer.from("020000208ec39428b17323fa0ddec8e887b4a7\
+     * c53b8c0a0a220cfd0000000000000000005b0750fce0a889502d40508d39576821155e9c9e3f5c\
+     * 3157f961db38fd8b25be1e77a759e93c0118a4ffd71d"), "hex");
+     * const block = await BlockHeader.fromBuffer(buffer);
+     * ```
+     */
+    public static fromBuffer(buf: Buffer): BlockHeader {
+        const r = new BufferReader(buf);
+        const version = r.readUInt32LE();
+        const previousBlockHash = new HashValue(r.readBytes(32));
+        const merkleRoot = new HashValue(r.readBytes(32));
+        const timestamp = r.readUInt32LE();
+        const bits = Bits.fromBuffer(r.readBytes(4));
+        const nonce = r.readUInt32LE();
+        return new BlockHeader(version, previousBlockHash, merkleRoot, timestamp, bits, nonce);
+    }
+
+    /**
+     * Version is normally used for signaling which features are
+     * available. Bitcoin blocks used sequential versions up through
+     * version 4. After this, BIP0009 was used to indicate that
+     * additional versioning bits could be used.
+     */
+    public version: number;
+
+    /**
+     * Previous block as a 32-bytes hash value
+     */
+    public previousBlockHash: HashValue;
+
+    /**
+     * Merkle root as 32-bytes hash value. This encodes all ordered
+     * transactions in a 32-byte hash.
+     */
+    public merkleRoot: HashValue;
+
+    /**
+     * Unix style timestamp which is the number of seconds elapsed since
+     * January 1, 1970. This value will eventually overflow in 2106.
+     */
+    public timestamp: number;
+
+    /**
+     * Bits encodes the proof-of-work necessary in this block. It
+     * contains two parts: exponent and coefficient. It is a succinct
+     * way to express a really large number and can represent either
+     * a positive or negative number.
+     */
+    public bits: Bits;
+
+    /**
+     * Nonce stands for number used only once. It is the number changed
+     * by miners when looking for proof-of-work.
+     */
+    public nonce: number;
+
+    public constructor(
+        version: number,
+        previousBlockHash: HashValue,
+        merkleRoot: HashValue,
+        timestamp: number,
+        bits: Bits,
+        nonce: number,
+    ) {
+        this.version = version;
+        this.previousBlockHash = previousBlockHash;
+        this.merkleRoot = merkleRoot;
+        this.timestamp = timestamp;
+        this.bits = bits;
+        this.nonce = nonce;
+    }
+
+    /**
+     * Serializes the block into a `Buffer` as received over the wire
+     * accordingly:
+     *
+     * version - 4 bytes LE
+     * previous block - 32 bytes, internal order (LE)
+     * merkle root - 32 bytes, internal order (LE)
+     * timestamp - 4 bytes LE
+     * bits - 4 bytes LE
+     * nonce - 4 bytes LE
+     */
+    public toBuffer(): Buffer {
+        const result = new BufferWriter(Buffer.alloc(4 + 32 + 32 + 4 + 4 + 4)); // 80
+
+        result.writeUInt32LE(this.version);
+        result.writeBytes(this.previousBlockHash.serialize(HashByteOrder.Internal));
+        result.writeBytes(this.merkleRoot.serialize(HashByteOrder.Internal));
+        result.writeUInt32LE(this.timestamp);
+        result.writeBytes(this.bits.toBuffer());
+        result.writeUInt32LE(this.nonce);
+
+        return result.toBuffer();
+    }
+
+    /**
+     * Returns the `hash256` of the block header in RPC byte order. This
+     * value will have leading zeros and looks like:
+     * 0000000000000000007e9e4c586439b0cdbe13b1370bdd9435d76a644d047523
+     *
+     * Because this value can be directly converted into a hexadecimal
+     * number that can be compared to the target, it is considered
+     * big-endian.
+     */
+    public hash(): HashValue {
+        return new HashValue(hash256(this.toBuffer()));
+    }
+
+    /**
+     * Returns true if the block version supports BIP0009. Prior to this
+     * BIP, an incremental approach to block version was used
+     * culminating with version 4 blocks supporting BIP00065
+     * (OP_CHECKLOCKTIMEVERIFY).
+     *
+     * BIP0009 solves the problem of allowing multiple feature to be
+     * signaled on the network at a time. There can be 29 different
+     * features signalled at the same time.
+     *
+     * The top 3-bits of the version are fixed to 001 which indicates
+     * that BIP0009 is in use. This enables the range of bits for use
+     * [0x20000000...0x3FFFFFFF].
+     *
+     * The remaining 29 can signal readiness for a soft force. Once 95%
+     * of blocks signal readiness in a given 2016 block epoch the
+     * feature is activated by the network.
+     */
+    public isBip9(): boolean {
+        return this.version >> 29 === 1;
+    }
+
+    /**
+     * Checks if a BIP9 feature is enabled by looking at the version and
+     * checking if the specified bit is set. Each feature has a block
+     * range and bit. This function checks the bit only according to the
+     * algorithm:
+     *
+     * ```typescript
+     * (version >> bit && 1) === 1
+     * ```
+     * @param bit
+     * @returns
+     */
+    public isBip9Feature(bit: number): boolean {
+        return this.isBip9() && ((this.version >> bit) & 1) === 1;
+    }
+}

--- a/packages/bufio/__tests__/BufferWriter.spec.ts
+++ b/packages/bufio/__tests__/BufferWriter.spec.ts
@@ -215,6 +215,58 @@ describe("BufferWriter", () => {
         });
     }
 
+    describe(BufferWriter.prototype.writeUIntLE.name, () => {
+        let br: BufferWriter;
+        before(() => {
+            br = new BufferWriter();
+        });
+
+        it("writes start", () => {
+            br.writeUIntLE(0x01, 3);
+            expect(br.toHex()).to.equal("010000");
+        });
+
+        it("writes more and expands", () => {
+            br.writeUIntLE(0x010203, 3);
+            expect(br.toHex()).to.equal("010000030201");
+        });
+
+        it("throws when number exceeds byte length", () => {
+            expect(() => br.writeUIntLE(0x0100, 1)).to.throw("Value 256 exceeds byte length 1");
+        });
+
+        it("throws out-of-range exception when exceeds fixed buffer size", () => {
+            const br = new BufferWriter(Buffer.alloc(2));
+            expect(() => br.writeUIntLE(0x010203, 3)).to.throw();
+        });
+    });
+
+    describe(BufferWriter.prototype.writeUIntBE.name, () => {
+        let br: BufferWriter;
+        before(() => {
+            br = new BufferWriter();
+        });
+
+        it("writes start", () => {
+            br.writeUIntBE(0x01, 3);
+            expect(br.toHex()).to.equal("000001");
+        });
+
+        it("writes more and expands", () => {
+            br.writeUIntBE(0x010203, 3);
+            expect(br.toHex()).to.equal("000001010203");
+        });
+
+        it("throws when number exceeds byte length", () => {
+            expect(() => br.writeUIntBE(0x0100, 1)).to.throw("Value 256 exceeds byte length 1");
+        });
+
+        it("throws out-of-range exception when exceeds fixed buffer size", () => {
+            const br = new BufferWriter(Buffer.alloc(2));
+            expect(() => br.writeUIntBE(0x010203, 3)).to.throw();
+        });
+    });
+
     describe("writeBytes", () => {
         let br: BufferWriter;
         before(() => {

--- a/packages/bufio/__tests__/UintBytes.spec.ts
+++ b/packages/bufio/__tests__/UintBytes.spec.ts
@@ -1,0 +1,18 @@
+import { expect } from "chai";
+import { uintBytes } from "../lib/UintBytes";
+
+describe(uintBytes.name, () => {
+    const tests: Array<[number, number]> = [
+        [0, 0],
+        [1, 1],
+        [255, 1],
+        [256, 2],
+        [65535, 2],
+        [65536, 3],
+    ];
+    for (const test of tests) {
+        it(`${test[0]} === ${test[1]} bytes`, () => {
+            expect(uintBytes(test[0])).to.deep.equal(test[1]);
+        });
+    }
+});

--- a/packages/bufio/lib/BufferWriter.ts
+++ b/packages/bufio/lib/BufferWriter.ts
@@ -1,3 +1,5 @@
+import { uintBytes } from "./UintBytes";
+
 /**
  * Utility class for writing arbitrary data into a Buffer. This class will
  * automatically expand the underlying Buffer and return a trimmed view
@@ -38,6 +40,15 @@ export class BufferWriter {
     public toBuffer(): Buffer {
         if (this._fixed) return this._buffer;
         else return this._buffer.slice(0, this._position);
+    }
+
+    /**
+     * Returns the Buffer as a hex encoded string. This is functionally
+     * a call to `toBuffer` followed by `toString("hex")`.
+     * @returns
+     */
+    public toHex(): string {
+        return this.toBuffer().toString("hex");
     }
 
     /**
@@ -108,6 +119,34 @@ export class BufferWriter {
         }
         const buf = Buffer.from(val.toString(16).padStart(16, "0"), "hex");
         this.writeBytes(buf);
+    }
+
+    /**
+     * Writes the number in the specified number of bytes.
+     * @param val
+     * @param bytes
+     */
+    public writeUIntLE(val: number, len: number) {
+        if (uintBytes(val) > len) {
+            throw new RangeError(`Value ${val} exceeds byte length ${len}`);
+        }
+        this._expand(len);
+        this._buffer.writeUIntLE(val, this._position, len);
+        this._position += len;
+    }
+
+    /**
+     * Writes the number in the specified number of bytes.
+     * @param value
+     * @param bytes
+     */
+    public writeUIntBE(val: number, len: number) {
+        if (uintBytes(val) > len) {
+            throw new RangeError(`Value ${val} exceeds byte length ${len}`);
+        }
+        this._expand(len);
+        this._buffer.writeUIntBE(val, this._position, len);
+        this._position += len;
     }
 
     /**

--- a/packages/bufio/lib/UintBytes.ts
+++ b/packages/bufio/lib/UintBytes.ts
@@ -1,0 +1,3 @@
+export function uintBytes(num: number): number {
+    return Math.ceil(Math.log2(num + 1) / 8);
+}

--- a/packages/bufio/lib/index.ts
+++ b/packages/bufio/lib/index.ts
@@ -8,4 +8,5 @@ export * from "./BufferReader";
 export * from "./BufferWriter";
 export * from "./Hex";
 export * from "./StreamReader";
+export * from "./UintBytes";
 export * from "./varIntBytes";


### PR DESCRIPTION
Creates the `BlockHeader` type and adds buffer IO methods. Also adds ability to create the Block hash from the header.

Closes #247 