### PR TITLE
bitcoin: create OutPoint eq methods

### DIFF
--- a/packages/bitcoin/__tests__/HashValue.spec.ts
+++ b/packages/bitcoin/__tests__/HashValue.spec.ts
@@ -101,4 +101,29 @@ describe("HashValue", () => {
             expect((a as any)._value).to.not.equal((b as any)._value);
         });
     });
+
+    describe(".eq()", () => {
+        it("false other is undefined", () => {
+            const a = new HashValue(Buffer.from([1, 2, 3]));
+            const b = undefined;
+            expect(a.eq(b)).to.equal(false);
+        });
+        it("false when unequal length", () => {
+            const a = new HashValue(Buffer.from([1, 2, 3]));
+            const b = new HashValue(Buffer.from([1, 2]));
+            expect(a.eq(b)).to.equal(false);
+        });
+
+        it("false when not same value", () => {
+            const a = new HashValue(Buffer.from([1, 2, 3]));
+            const b = new HashValue(Buffer.from([1, 2, 4]));
+            expect(a.eq(b)).to.equal(false);
+        });
+
+        it("true when same value", () => {
+            const a = new HashValue(Buffer.from([1, 2, 3]));
+            const b = new HashValue(Buffer.from([1, 2, 3]));
+            expect(a.eq(b)).to.equal(true);
+        });
+    });
 });

--- a/packages/bitcoin/__tests__/OutPoint.spec.ts
+++ b/packages/bitcoin/__tests__/OutPoint.spec.ts
@@ -41,4 +41,44 @@ describe("OutPoint", () => {
             expect(a.outputIndex).to.equal(b.outputIndex);
         });
     });
+
+    describe(".eq()", () => {
+        it("returns false when other is undefined", () => {
+            const a = OutPoint.fromString(
+                "0000000000000000000000000000000000000000000000000000000000000001:0",
+            );
+            const b = undefined;
+            expect(a.eq(b)).to.equal(false);
+        });
+
+        it("returns false when txid is different", () => {
+            const a = OutPoint.fromString(
+                "0000000000000000000000000000000000000000000000000000000000000001:0",
+            );
+            const b = OutPoint.fromString(
+                "0000000000000000000000000000000000000000000000000000000000000002:0",
+            );
+            expect(a.eq(b)).to.equal(false);
+        });
+
+        it("returns false when output index is different", () => {
+            const a = OutPoint.fromString(
+                "0000000000000000000000000000000000000000000000000000000000000001:0",
+            );
+            const b = OutPoint.fromString(
+                "0000000000000000000000000000000000000000000000000000000000000001:1",
+            );
+            expect(a.eq(b)).to.equal(false);
+        });
+
+        it("returns true when both are equal", () => {
+            const a = OutPoint.fromString(
+                "0000000000000000000000000000000000000000000000000000000000000001:0",
+            );
+            const b = OutPoint.fromString(
+                "0000000000000000000000000000000000000000000000000000000000000001:0",
+            );
+            expect(a.eq(b)).to.equal(true);
+        });
+    });
 });

--- a/packages/bitcoin/lib/HashValue.ts
+++ b/packages/bitcoin/lib/HashValue.ts
@@ -86,4 +86,14 @@ export class HashValue implements ICloneable<HashValue> {
     public clone(): HashValue {
         return new HashValue(Buffer.from(this._value));
     }
+
+    /**
+     * Returns true if there is byte-wise equality
+     * @param other
+     * @returns
+     */
+    public eq(other: HashValue): boolean {
+        if (other === undefined) return false;
+        return this._value.equals(other._value);
+    }
 }

--- a/packages/bitcoin/lib/OutPoint.ts
+++ b/packages/bitcoin/lib/OutPoint.ts
@@ -96,4 +96,15 @@ export class OutPoint implements ICloneable<OutPoint> {
     public clone(): OutPoint {
         return new OutPoint(this.txid.clone(), this.outputIndex);
     }
+
+    /**
+     * Returns true when both the transaction identifier and the output
+     * index are equal.
+     * @param other
+     * @returns
+     */
+    public eq(other: OutPoint): boolean {
+        if (other === undefined) return false;
+        return this.txid.eq(other.txid) && this.outputIndex === other.outputIndex;
+    }
 }


### PR DESCRIPTION
Helpers methods added to `HashValue` and `OutPoint` to test for equality.

Closes #249 