### PR TITLE
bitcoin: convert TxBuilder sign methods to use PrivateKey

### DIFF
--- a/packages/bitcoin/__tests__/TxBuilder.spec.ts
+++ b/packages/bitcoin/__tests__/TxBuilder.spec.ts
@@ -1,6 +1,6 @@
 import { StreamReader } from "@node-lightning/bufio";
-import { getPublicKey, hash160 } from "@node-lightning/crypto";
 import { expect } from "chai";
+import { PrivateKey } from "../lib/PrivateKey";
 import { LockTime } from "../lib/LockTime";
 import { OpCode } from "../lib/OpCodes";
 import { Script } from "../lib/Script";
@@ -10,21 +10,29 @@ import { TxBuilder } from "../lib/TxBuilder";
 import { TxIn } from "../lib/TxIn";
 import { TxOut } from "../lib/TxOut";
 import { Value } from "../lib/Value";
+import { Network } from "../lib/Network";
+import { PublicKey } from "../lib/PublicKey";
 
 describe("TxBuilder", () => {
     // address: mufrrGX5ei1g2GBjKBBYvidioNqN7GWJsD
     // pkh:     9b40f5b05efd99e4b0c4f62ca63eec3e580e95c7
     // wif:     cSV9NvF6Gk3gTXgrpfPrjkHCyb4CLQZD3nsQSYUKGH4PPsRS8J2M
-    const privA = Buffer.from("92541d4cdb6f0db05949e4fd91d7cb936f84eb21a62b477103d0e1957e6ad782", "hex"); // prettier-ignore
-    const pubkeyA = getPublicKey(privA, true);
-    const pubkeyHashA = hash160(pubkeyA);
+    const privA = new PrivateKey(
+        Buffer.from("92541d4cdb6f0db05949e4fd91d7cb936f84eb21a62b477103d0e1957e6ad782", "hex"),
+        Network.mainnet,
+    );
+    const pubkeyA = privA.toPubKey(true);
+    const pubkeyHashA = pubkeyA.hash160();
 
     // address: myVmRHXHq6qzW7s7TCseBLLgajKxT6Z19j
     // pkh:     c538c517797dfefdf30142dc1684bfd947532dbb
     // wif:     cSAyZjTwLx2eh76MfL5zmGV8n7pk61Lx5We2S95UGyhiwoSgJgv2
-    const privB = Buffer.from("88fb4d47adfd310bf071d67c8ac569f58d8e4c4d8d94b778c010ddd0e2ff6a48", "hex"); // prettier-ignore
-    const pubkeyB = getPublicKey(privB, true);
-    const pubkeyHashB = hash160(pubkeyB);
+    const privB = new PrivateKey(
+        Buffer.from("88fb4d47adfd310bf071d67c8ac569f58d8e4c4d8d94b778c010ddd0e2ff6a48", "hex"),
+        Network.mainnet,
+    );
+    const pubkeyB = privB.toPubKey(true);
+    const pubkeyHashB = pubkeyB.hash160();
 
     describe(".sign()", () => {
         it("p2pkh", () => {
@@ -42,9 +50,9 @@ describe("TxBuilder", () => {
         it("p2pk", () => {
             const sut = new TxBuilder();
             sut.addInput("68ce1030a63bd7ff44a95f497d3535731cfa3e6b89eda5ce38eb37a6d527d0dc:0"); // prettier-ignore
-            sut.addOutput(49.9998, Script.p2pkLock(pubkeyB));
+            sut.addOutput(49.9998, Script.p2pkLock(pubkeyB.toBuffer()));
 
-            const commitScript = Script.p2pkLock(pubkeyA);
+            const commitScript = Script.p2pkLock(pubkeyA.toBuffer());
             const sig = sut.sign(0, commitScript, privA);
             expect(sig.toString("hex")).to.equal(
                 "3045022100d87f7a819cb6ff3140c5ab0f20def422ae1eaa8aade78c33c2368b6be2609d2b022049581379f827bb08f088591d40f7890526aa17403d3e77d2af411774338de7ce01",
@@ -52,8 +60,20 @@ describe("TxBuilder", () => {
         });
 
         it("BIP P2WPKH test vector", () => {
-            const priv2 = Buffer.from("619c335025c7f4012e556c2a58b2506e30b8511b53ade95ea316fd8c3286feb9", "hex"); // prettier-ignore
-            const pubkey2 = Buffer.from("025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357", "hex"); // prettier-ignore
+            const priv2 = new PrivateKey(
+                Buffer.from(
+                    "619c335025c7f4012e556c2a58b2506e30b8511b53ade95ea316fd8c3286feb9",
+                    "hex",
+                ),
+                Network.mainnet,
+            );
+            const pubkey2 = new PublicKey(
+                Buffer.from(
+                    "025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357",
+                    "hex",
+                ),
+                Network.mainnet,
+            );
 
             const tx = new TxBuilder();
             tx.version = 1;
@@ -64,7 +84,7 @@ describe("TxBuilder", () => {
             tx.locktime = LockTime.parse(StreamReader.fromHex("11000000"));
 
             const index = 1;
-            const commitScript = Script.p2pkhLock(pubkey2);
+            const commitScript = Script.p2pkhLock(pubkey2.toBuffer());
             const value = Value.fromBitcoin(6);
 
             const hash = tx.hashSegwitv0(index, commitScript, value);
@@ -79,8 +99,20 @@ describe("TxBuilder", () => {
         });
 
         it("BIP143 P2SH-P2WPKH test vector", () => {
-            const privkey = Buffer.from("eb696a065ef48a2192da5b28b694f87544b30fae8327c4510137a922f32c6dcf", "hex"); // prettier-ignore
-            const pubkey = Buffer.from("03ad1d8e89212f0b92c74d23bb710c00662ad1470198ac48c43f7d6f93a2a26873", "hex"); // prettier-ignore
+            const privkey = new PrivateKey(
+                Buffer.from(
+                    "eb696a065ef48a2192da5b28b694f87544b30fae8327c4510137a922f32c6dcf",
+                    "hex",
+                ),
+                Network.mainnet,
+            );
+            const pubkey = new PublicKey(
+                Buffer.from(
+                    "03ad1d8e89212f0b92c74d23bb710c00662ad1470198ac48c43f7d6f93a2a26873",
+                    "hex",
+                ),
+                Network.mainnet,
+            );
 
             const tx = new TxBuilder();
             tx.version = 1;
@@ -90,7 +122,7 @@ describe("TxBuilder", () => {
             tx.locktime = LockTime.parse(StreamReader.fromHex("92040000"));
 
             const index = 0;
-            const commitScript = Script.p2pkhLock(pubkey);
+            const commitScript = Script.p2pkhLock(pubkey.toBuffer());
             const value = Value.fromBitcoin(10);
 
             const hash = tx.hashSegwitv0(index, commitScript, value);
@@ -113,7 +145,7 @@ describe("TxBuilder", () => {
 
             const commitScript = Script.p2pkhLock(pubkeyHashA);
             const sig = sut.sign(0, commitScript, privA);
-            sut.setScriptSig(0, Script.p2pkhUnlock(sig, pubkeyA));
+            sut.setScriptSig(0, Script.p2pkhUnlock(sig, pubkeyA.toBuffer()));
 
             expect(sut.serialize().toString("hex")).to.equal(
                 "020000000168de699575d42639235114a0b9b43a6ed3317e72b60601ad9f0a0273ad630e9d000000006b4830450221009fdc678141bfad627023ae38336716543f91c1b12462673bc9d4fddd6cba5f3c02202e8dd9c9ce538c6bc9b29612ccbf07b3051c13e0f40e92ce3e663060da4c803a012102c13bf903d6147a7fec59b450e2e8a6c174c35a11a7675570d10bd05bc3597996ffffffff01f0ca052a010000001976a914c538c517797dfefdf30142dc1684bfd947532dbb88acffffffff",
@@ -123,9 +155,9 @@ describe("TxBuilder", () => {
         it("spend p2pk to p2pk output", () => {
             const sut = new TxBuilder();
             sut.addInput("68ce1030a63bd7ff44a95f497d3535731cfa3e6b89eda5ce38eb37a6d527d0dc:0"); // prettier-ignore
-            sut.addOutput(49.9998, Script.p2pkLock(pubkeyB));
+            sut.addOutput(49.9998, Script.p2pkLock(pubkeyB.toBuffer()));
 
-            const commitScript = Script.p2pkLock(pubkeyA);
+            const commitScript = Script.p2pkLock(pubkeyA.toBuffer());
             const sig = sut.sign(0, commitScript, privA);
             sut.setScriptSig(0, Script.p2pkUnlock(sig));
 
@@ -141,7 +173,7 @@ describe("TxBuilder", () => {
 
             const commitScript = Script.p2pkhLock(pubkeyHashA);
             const sig = sut.sign(0, commitScript, privA);
-            sut.setScriptSig(0, Script.p2pkhUnlock(sig, pubkeyA));
+            sut.setScriptSig(0, Script.p2pkhUnlock(sig, pubkeyA.toBuffer()));
 
             expect(sut.serialize().toString("hex")).to.equal(
                 "0200000001d9f0f6a22a81b0ec0e40a97c65b36b15e02ee9abf0a3d848212f38ec3ebd5bca000000006a47304402205b1d47b4f0db4fe99b035a87649fbdfc3867e10950d5412b2875cd3774a052c2022037e3c70bfa8e237ed409e409bf6c8b0aa574e44297ed4fc868264ce5148d437a012102c13bf903d6147a7fec59b450e2e8a6c174c35a11a7675570d10bd05bc3597996ffffffff01f0ca052a0100000017a914a7b6b1cc86e6d0b8876040a46da5a346b8662db487ffffffff",
@@ -151,11 +183,11 @@ describe("TxBuilder", () => {
         it("spend p2pkh to p2ms", () => {
             const sut = new TxBuilder();
             sut.addInput("997fd2dd17a5d5843edc23ab7f043130dfe737cf0e02336c75fe37c1eda51195:0");
-            sut.addOutput(49.9999, Script.p2msLock(2, pubkeyA, pubkeyB));
+            sut.addOutput(49.9999, Script.p2msLock(2, pubkeyA.toBuffer(), pubkeyB.toBuffer()));
 
             const commitScript = Script.p2pkhLock(pubkeyHashA);
             const sig = sut.sign(0, commitScript, privA);
-            sut.setScriptSig(0, Script.p2pkhUnlock(sig, pubkeyA));
+            sut.setScriptSig(0, Script.p2pkhUnlock(sig, pubkeyA.toBuffer()));
 
             expect(sut.serialize().toString("hex")).to.equal(
                 "02000000019511a5edc137fe756c33020ecf37e7df3031047fab23dc3e84d5a517ddd27f99000000006b483045022100eca82b19d1954f6f24292b12dfc49379b536c65c32871309a81ec220750a07bd02205fdff7a71a4727e2fb17b7f089037054a5e6ef30c3ce12796c661ec690292443012102c13bf903d6147a7fec59b450e2e8a6c174c35a11a7675570d10bd05bc3597996ffffffff01f0ca052a0100000047522102c13bf903d6147a7fec59b450e2e8a6c174c35a11a7675570d10bd05bc3597996210334acee9adf0e3e490a422dfe98bc10a8091b43047b793b8d840657b6b6a46c5652aeffffffff",
@@ -167,7 +199,7 @@ describe("TxBuilder", () => {
             sut.addInput("d6422b4b4c9ec2e8f5f6eaff948241c494397f7e6ca4a2ca2783e3ea3581e27f:0");
             sut.addOutput(49.9998, Script.p2pkhLock(pubkeyHashB));
 
-            const commitScript = Script.p2msLock(2, pubkeyA, pubkeyB);
+            const commitScript = Script.p2msLock(2, pubkeyA.toBuffer(), pubkeyB.toBuffer());
             const sigA = sut.sign(0, commitScript, privA);
             const sigB = sut.sign(0, commitScript, privB);
             const scriptSig = Script.p2msUnlock(sigA, sigB);
@@ -190,7 +222,7 @@ describe("TxBuilder", () => {
 
             const commitScript = Script.p2pkhLock(pubkeyHashA);
             const sig = sut.sign(0, commitScript, privA);
-            sut.setScriptSig(0, Script.p2shUnlock(commitScript, sig, pubkeyA));
+            sut.setScriptSig(0, Script.p2shUnlock(commitScript, sig, pubkeyA.toBuffer()));
 
             expect(sut.serialize().toString("hex")).to.equal(
                 "0200000001d9c8b29caba1b353d90fde1f83dc6cf386be147c282e2f2abeb140160cbbe533000000008447304402206cada8b4b6caeadf293627f841244f730aaed74f53709982fd24776643a658d8022026614f756642e08c08b20546f894396187ec1a4ea709a1c69cd036b3ac2f6441012102c13bf903d6147a7fec59b450e2e8a6c174c35a11a7675570d10bd05bc35979961976a9149b40f5b05efd99e4b0c4f62ca63eec3e580e95c788acffffffff01e0a3052a0100000017a9141fec31deece63a911dd9b22fa974ba9760d1bc3d87ffffffff",
@@ -224,11 +256,14 @@ describe("TxBuilder", () => {
         it("spends p2pkh to p2sh-p2ms", () => {
             const sut = new TxBuilder();
             sut.addInput("0382e83cc4692fbd554d621c214263a3414ec0cbbdef0fee73b16992613b8809:0");
-            sut.addOutput(49.9999, Script.p2shLock(Script.p2msLock(2, pubkeyA, pubkeyB)));
+            sut.addOutput(
+                49.9999,
+                Script.p2shLock(Script.p2msLock(2, pubkeyA.toBuffer(), pubkeyB.toBuffer())),
+            );
 
             const commitScript = Script.p2pkhLock(pubkeyHashA);
             const sig = sut.sign(0, commitScript, privA);
-            sut.setScriptSig(0, Script.p2pkhUnlock(sig, pubkeyA));
+            sut.setScriptSig(0, Script.p2pkhUnlock(sig, pubkeyA.toBuffer()));
 
             expect(sut.serialize().toString("hex")).to.equal(
                 "020000000109883b619269b173ee0fefbdcbc04e41a36342211c624d55bd2f69c43ce88203000000006b483045022100b5e8805ca04c0c360fad14768792aaeb80b1be3480e3d69b830ae4903dbc731d02206a4ca0e5e650b709ad94bfb8762bd81d4b31192417d1f9d1956b3b27bce616c6012102c13bf903d6147a7fec59b450e2e8a6c174c35a11a7675570d10bd05bc3597996ffffffff01f0ca052a0100000017a914c5421130046c411fc4616d54d6ba0412328c32cf87ffffffff",
@@ -240,7 +275,7 @@ describe("TxBuilder", () => {
             sut.addInput("26aec57587f3e093f8236706873e3c71f95c18310b688925e657ef9b9ce0309d:0");
             sut.addOutput(49.9998, Script.p2pkhLock(pubkeyHashB));
 
-            const commitScript = Script.p2msLock(2, pubkeyA, pubkeyB);
+            const commitScript = Script.p2msLock(2, pubkeyA.toBuffer(), pubkeyB.toBuffer());
             const sigA = sut.sign(0, commitScript, privA);
             const sigB = sut.sign(0, commitScript, privB);
             sut.setScriptSig(0, Script.p2shUnlock(commitScript, Script.p2msUnlock(sigA, sigB)));
@@ -261,7 +296,7 @@ describe("TxBuilder", () => {
 
             const commitScript = Script.p2pkhLock(pubkeyHashA);
             const sig = sut.sign(0, commitScript, privA);
-            sut.setScriptSig(0, Script.p2pkhUnlock(sig, pubkeyA));
+            sut.setScriptSig(0, Script.p2pkhUnlock(sig, pubkeyA.toBuffer()));
 
             expect(sut.serialize().toString("hex")).to.equal(
                 "0200000001de6aa12d0381d6678416e76bd2562eb1d26b15333b6ebf3bb1f96012fe679c5d000000006b483045022100922d11bf27877bb36a9090b3d71ea39b653b3f21d3019e82243c1021b781b8dd022071bfded587414b0a833d9f9c06db8745ff05a199066e05a8f3dc3b2a6a670a5c012102c13bf903d6147a7fec59b450e2e8a6c174c35a11a7675570d10bd05bc3597996ffffffff02f0ca052a010000001976a9149b40f5b05efd99e4b0c4f62ca63eec3e580e95c788ac0000000000000000176a155361746f736869206973206d7920686f6d65626f79ffffffff",
@@ -274,11 +309,14 @@ describe("TxBuilder", () => {
                 "0085855136b41b0318ba66a33704e1b4a0903e4cf30563a47185e9ce4842f8cb:0",
                 Sequence.zero(),
             );
-            original.addOutput(49.9999, Script.p2pkhLock(pubkeyB));
+            original.addOutput(49.9999, Script.p2pkhLock(pubkeyB.toBuffer()));
             original.setLockTime(0);
             original.setScriptSig(
                 0,
-                Script.p2pkhUnlock(original.sign(0, Script.p2pkhLock(pubkeyA), privA), pubkeyA),
+                Script.p2pkhUnlock(
+                    original.sign(0, Script.p2pkhLock(pubkeyA.toBuffer()), privA),
+                    pubkeyA.toBuffer(),
+                ),
             );
 
             expect(original.serialize().toString("hex")).to.equal(
@@ -290,11 +328,14 @@ describe("TxBuilder", () => {
                 "0085855136b41b0318ba66a33704e1b4a0903e4cf30563a47185e9ce4842f8cb:0",
                 Sequence.rbf(),
             );
-            replacement.addOutput(49.9998, Script.p2pkhLock(pubkeyB));
+            replacement.addOutput(49.9998, Script.p2pkhLock(pubkeyB.toBuffer()));
             replacement.locktime = LockTime.zero();
             replacement.setScriptSig(
                 0,
-                Script.p2pkhUnlock(replacement.sign(0, Script.p2pkhLock(pubkeyA), privA), pubkeyA),
+                Script.p2pkhUnlock(
+                    replacement.sign(0, Script.p2pkhLock(pubkeyA.toBuffer()), privA),
+                    pubkeyA.toBuffer(),
+                ),
             );
 
             expect(replacement.serialize().toString("hex")).to.equal(
@@ -305,10 +346,13 @@ describe("TxBuilder", () => {
         it("spends CPFP transaction", () => {
             const parent = new TxBuilder();
             parent.addInput("55151071faaf2fe3081cd84cb3e8b6c7fdeb3ffa009747d727d7b99b820094a5:0");
-            parent.addOutput(49.99999, Script.p2pkhLock(pubkeyB));
+            parent.addOutput(49.99999, Script.p2pkhLock(pubkeyB.toBuffer()));
             parent.setScriptSig(
                 0,
-                Script.p2pkhUnlock(parent.sign(0, Script.p2pkhLock(pubkeyA), privA), pubkeyA),
+                Script.p2pkhUnlock(
+                    parent.sign(0, Script.p2pkhLock(pubkeyA.toBuffer()), privA),
+                    pubkeyA.toBuffer(),
+                ),
             );
 
             expect(parent.serialize().toString("hex")).to.equal(
@@ -317,10 +361,13 @@ describe("TxBuilder", () => {
 
             const child = new TxBuilder();
             child.addInput("5553a10a7eed240ee96f7274159b039f7df22c76c580193ef2f4e7f70b4537e0:0");
-            child.addOutput(49.9999, Script.p2pkhLock(pubkeyB));
+            child.addOutput(49.9999, Script.p2pkhLock(pubkeyB.toBuffer()));
             child.setScriptSig(
                 0,
-                Script.p2pkhUnlock(parent.sign(0, Script.p2pkhLock(pubkeyB), privB), pubkeyB),
+                Script.p2pkhUnlock(
+                    parent.sign(0, Script.p2pkhLock(pubkeyB.toBuffer()), privB),
+                    pubkeyB.toBuffer(),
+                ),
             );
 
             expect(parent.serialize().toString("hex")).to.equal(
@@ -333,7 +380,7 @@ describe("TxBuilder", () => {
                 Script.number(200),
                 OpCode.OP_CHECKLOCKTIMEVERIFY,  // output is unspendable until block 200
                 OpCode.OP_DROP,                 // drop the 200
-                pubkeyB,
+                pubkeyB.toBuffer(),
                 OpCode.OP_CHECKSIG,             // only spendable to B
             ); // prettier-ignore
 
@@ -342,7 +389,10 @@ describe("TxBuilder", () => {
             tx1.addOutput(49.9999, Script.p2shLock(redeem)); // use p2sh to wrap script
             tx1.setScriptSig(
                 0,
-                Script.p2pkhUnlock(tx1.sign(0, Script.p2pkhLock(pubkeyA), privA), pubkeyA),
+                Script.p2pkhUnlock(
+                    tx1.sign(0, Script.p2pkhLock(pubkeyA.toBuffer()), privA),
+                    pubkeyA.toBuffer(),
+                ),
             );
 
             expect(tx1.serialize().toString("hex")).to.equal(
@@ -354,7 +404,7 @@ describe("TxBuilder", () => {
                 "db82b592c04587796a2eb43e00fe6e9f342383c747ef356f92d5fb21c4a95b89:0",
                 Sequence.locktime(), // required to enable locktime
             );
-            tx2.addOutput(49.9998, Script.p2pkhLock(pubkeyB));
+            tx2.addOutput(49.9998, Script.p2pkhLock(pubkeyB.toBuffer()));
             tx2.setLockTime(200); // locktime must be >= the input value for CLTV
             tx2.setScriptSig(0, Script.p2shUnlock(redeem, tx2.sign(0, redeem, privB))); // provide the redeem script and the signature
 
@@ -368,7 +418,7 @@ describe("TxBuilder", () => {
                 Script.number(1612137600),
                 OpCode.OP_CHECKLOCKTIMEVERIFY,  // output is unspendable until Feb 01 2021
                 OpCode.OP_DROP,                 // drop the timelock
-                pubkeyB,
+                pubkeyB.toBuffer(),
                 OpCode.OP_CHECKSIG,             // only spendable to B
             ); // prettier-ignore
 
@@ -377,7 +427,10 @@ describe("TxBuilder", () => {
             tx1.addOutput(49.9999, Script.p2shLock(redeem)); // use p2sh to wrap script
             tx1.setScriptSig(
                 0,
-                Script.p2pkhUnlock(tx1.sign(0, Script.p2pkhLock(pubkeyA), privA), pubkeyA),
+                Script.p2pkhUnlock(
+                    tx1.sign(0, Script.p2pkhLock(pubkeyA.toBuffer()), privA),
+                    pubkeyA.toBuffer(),
+                ),
             );
 
             expect(tx1.serialize().toString("hex")).to.equal(
@@ -389,7 +442,7 @@ describe("TxBuilder", () => {
                 "94bdc0c7d032a487b2d4637dfc9d6bd8788e5cf2ea8bde542dc2e99383f07877:0",
                 Sequence.locktime(), // required to enable locktime
             );
-            tx2.addOutput(49.9998, Script.p2pkhLock(pubkeyB));
+            tx2.addOutput(49.9998, Script.p2pkhLock(pubkeyB.toBuffer()));
             tx2.locktime = new LockTime(1612137600); // locktime must be >= the input value for CLTV
             tx2.setScriptSig(0, Script.p2shUnlock(redeem, tx2.sign(0, redeem, privB))); // provide the redeem script and the signature
 
@@ -405,7 +458,7 @@ describe("TxBuilder", () => {
                 Script.number(delay.value),
                 OpCode.OP_CHECKSEQUENCEVERIFY,
                 OpCode.OP_DROP,
-                pubkeyB,
+                pubkeyB.toBuffer(),
                 OpCode.OP_CHECKSIG,
             );
 
@@ -414,7 +467,10 @@ describe("TxBuilder", () => {
             tx1.addOutput(49.9999, Script.p2shLock(redeem));
             tx1.setScriptSig(
                 0,
-                Script.p2pkhUnlock(tx1.sign(0, Script.p2pkhLock(pubkeyA), privA), pubkeyA),
+                Script.p2pkhUnlock(
+                    tx1.sign(0, Script.p2pkhLock(pubkeyA.toBuffer()), privA),
+                    pubkeyA.toBuffer(),
+                ),
             );
 
             expect(tx1.serialize().toString("hex")).to.equal(
@@ -428,7 +484,7 @@ describe("TxBuilder", () => {
                 "6648789a901fb81d267ea6fdd63ce037487c2a43ddeaa2dde55daf49a7456c2f:0",
                 delay,
             );
-            tx2.addOutput(49.9998, Script.p2pkhLock(pubkeyB));
+            tx2.addOutput(49.9998, Script.p2pkhLock(pubkeyB.toBuffer()));
             tx2.locktime = LockTime.zero(); // required to enable csv
             tx2.setScriptSig(0, Script.p2shUnlock(redeem, tx2.sign(0, redeem, privB)));
 
@@ -444,7 +500,7 @@ describe("TxBuilder", () => {
                 Script.number(delay.value),
                 OpCode.OP_CHECKSEQUENCEVERIFY,
                 OpCode.OP_DROP,
-                pubkeyB,
+                pubkeyB.toBuffer(),
                 OpCode.OP_CHECKSIG,
             );
 
@@ -453,7 +509,10 @@ describe("TxBuilder", () => {
             tx1.addOutput(49.9999, Script.p2shLock(redeem));
             tx1.setScriptSig(
                 0,
-                Script.p2pkhUnlock(tx1.sign(0, Script.p2pkhLock(pubkeyA), privA), pubkeyA),
+                Script.p2pkhUnlock(
+                    tx1.sign(0, Script.p2pkhLock(pubkeyA.toBuffer()), privA),
+                    pubkeyA.toBuffer(),
+                ),
             );
 
             expect(tx1.serialize().toString("hex")).to.equal(
@@ -467,7 +526,7 @@ describe("TxBuilder", () => {
                 "affd587c75bc4ca8d9963f8c4a184e71bf8ca983ed67ee74749885c52df18e3d:0",
                 delay,
             );
-            tx2.addOutput(49.9998, Script.p2pkhLock(pubkeyB));
+            tx2.addOutput(49.9998, Script.p2pkhLock(pubkeyB.toBuffer()));
             tx2.locktime = LockTime.zero(); // required to enable csv
             tx2.setScriptSig(0, Script.p2shUnlock(redeem, tx2.sign(0, redeem, privB)));
 
@@ -479,12 +538,15 @@ describe("TxBuilder", () => {
         it("spends P2PKH to P2WPKH", () => {
             const tx = new TxBuilder();
             tx.addInput("5a31aa621739c5643c542538ca99d7c46a4462d0f32c81cb6bdb33dbb838ebb0:0");
-            tx.addOutput(49.9999, Script.p2wpkhLock(pubkeyB));
+            tx.addOutput(49.9999, Script.p2wpkhLock(pubkeyB.toBuffer()));
 
             // spends legacy p2pkh
             tx.setScriptSig(
                 0,
-                Script.p2pkhUnlock(tx.sign(0, Script.p2pkhLock(pubkeyA), privA), pubkeyA),
+                Script.p2pkhUnlock(
+                    tx.sign(0, Script.p2pkhLock(pubkeyA.toBuffer()), privA),
+                    pubkeyA.toBuffer(),
+                ),
             );
 
             expect(tx.serialize().toString("hex")).to.equal(
@@ -493,11 +555,35 @@ describe("TxBuilder", () => {
         });
 
         it("BIP143 P2WPKH Test Vector", () => {
-            const priv1 = Buffer.from("bbc27228ddcb9209d7fd6f36b02f7dfa6252af40bb2f1cbc7a557da8027ff866", "hex"); // prettier-ignore
-            const pubkey1 = Buffer.from("03c9f4836b9a4f77fc0d81f7bcb01b7f1b35916864b9476c241ce9fc198bd25432", "hex"); // prettier-ignore
+            const priv1 = new PrivateKey(
+                Buffer.from(
+                    "bbc27228ddcb9209d7fd6f36b02f7dfa6252af40bb2f1cbc7a557da8027ff866",
+                    "hex",
+                ),
+                Network.mainnet,
+            );
+            const pubkey1 = new PublicKey(
+                Buffer.from(
+                    "03c9f4836b9a4f77fc0d81f7bcb01b7f1b35916864b9476c241ce9fc198bd25432",
+                    "hex",
+                ),
+                Network.mainnet,
+            );
 
-            const priv2 = Buffer.from("619c335025c7f4012e556c2a58b2506e30b8511b53ade95ea316fd8c3286feb9", "hex"); // prettier-ignore
-            const pubkey2 = Buffer.from("025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357", "hex"); // prettier-ignore
+            const priv2 = new PrivateKey(
+                Buffer.from(
+                    "619c335025c7f4012e556c2a58b2506e30b8511b53ade95ea316fd8c3286feb9",
+                    "hex",
+                ),
+                Network.mainnet,
+            );
+            const pubkey2 = new PublicKey(
+                Buffer.from(
+                    "025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357",
+                    "hex",
+                ),
+                Network.mainnet,
+            );
 
             const tx = new TxBuilder();
             tx.version = 1;
@@ -508,11 +594,14 @@ describe("TxBuilder", () => {
             tx.locktime = LockTime.parse(StreamReader.fromHex("11000000"));
 
             // sign p2pk input and apply scriptsig
-            tx.setScriptSig(0, Script.p2pkUnlock(tx.sign(0, Script.p2pkLock(pubkey1), priv1)));
+            tx.setScriptSig(
+                0,
+                Script.p2pkUnlock(tx.sign(0, Script.p2pkLock(pubkey1.toBuffer()), priv1)),
+            );
 
             // sign p2wpkh input and apply to witness
-            tx.addWitness(1, tx.signSegWitv0(1, Script.p2pkhLock(pubkey2), priv2, 6));
-            tx.addWitness(1, pubkey2);
+            tx.addWitness(1, tx.signSegWitv0(1, Script.p2pkhLock(pubkey2.toBuffer()), priv2, 6));
+            tx.addWitness(1, pubkey2.toBuffer());
 
             expect(tx.serialize().toString("hex")).to.equal(
                 "01000000000102fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f00000000494830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01eeffffffef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff02202cb206000000001976a9148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093510d000000001976a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac000247304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee0121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635711000000",
@@ -522,11 +611,14 @@ describe("TxBuilder", () => {
         it("spends P2WPKH to P2WPKH", () => {
             const tx = new TxBuilder();
             tx.addInput("41e441eb2cfc6bc7dd238361daa4660677a1e253d4749a508ba26a83b84ce815:0");
-            tx.addOutput(49.9998, Script.p2wpkhLock(pubkeyA));
+            tx.addOutput(49.9998, Script.p2wpkhLock(pubkeyA.toBuffer()));
 
             // provide witness data to spend p2wpkh
-            tx.addWitness(0, tx.signSegWitv0(0, Script.p2pkhLock(pubkeyB), privB, 49.9999));
-            tx.addWitness(0, pubkeyB);
+            tx.addWitness(
+                0,
+                tx.signSegWitv0(0, Script.p2pkhLock(pubkeyB.toBuffer()), privB, 49.9999),
+            );
+            tx.addWitness(0, pubkeyB.toBuffer());
 
             expect(tx.serialize().toString("hex")).to.equal(
                 "0200000000010115e84cb8836aa28b509a74d453e2a1770666a4da618323ddc76bfc2ceb41e4410000000000ffffffff01e0a3052a010000001600149b40f5b05efd99e4b0c4f62ca63eec3e580e95c702483045022100a355feb29d36e89c3693a2d5e33c8143ffba3428db2cc0ace021d955a649d2c5022001298dddb1627e313664dbce0311c453939c6fa88ad3cb8ff6f49287d13b3d9f01210334acee9adf0e3e490a422dfe98bc10a8091b43047b793b8d840657b6b6a46c56ffffffff",
@@ -536,10 +628,18 @@ describe("TxBuilder", () => {
         it("spends P2PKH to P2WSH", () => {
             const tx = new TxBuilder();
             tx.addInput("b7c1cc3923e43147534ca19d05d0d2d666f5f95883bac08342b856a63f1b7f7a:0");
-            tx.addOutput(49.9999, Script.p2wshLock(Script.p2msLock(2, pubkeyA, pubkeyB).sha256()));
+            tx.addOutput(
+                49.9999,
+                Script.p2wshLock(
+                    Script.p2msLock(2, pubkeyA.toBuffer(), pubkeyB.toBuffer()).sha256(),
+                ),
+            );
             tx.setScriptSig(
                 0,
-                Script.p2pkhUnlock(tx.sign(0, Script.p2pkhLock(pubkeyA), privA), pubkeyA),
+                Script.p2pkhUnlock(
+                    tx.sign(0, Script.p2pkhLock(pubkeyA.toBuffer()), privA),
+                    pubkeyA.toBuffer(),
+                ),
             );
 
             expect(tx.serialize().toString("hex")).to.equal(
@@ -550,10 +650,10 @@ describe("TxBuilder", () => {
         it("spends P2WSH to P2WPK", () => {
             const tx = new TxBuilder();
             tx.addInput("c53bb09e5cd33bf9f314c8e43f9f5e9b7356433c48dc223740af493ab7069d40:0");
-            tx.addOutput(49.9998, Script.p2wpkhLock(pubkeyA));
+            tx.addOutput(49.9998, Script.p2wpkhLock(pubkeyA.toBuffer()));
             tx.addWitness(0, Buffer.alloc(0));
 
-            const commitScript = Script.p2msLock(2, pubkeyA, pubkeyB);
+            const commitScript = Script.p2msLock(2, pubkeyA.toBuffer(), pubkeyB.toBuffer());
             const value = Value.fromBitcoin(49.9999);
             tx.addWitness(0, tx.signSegWitv0(0, commitScript, privA, value));
             tx.addWitness(0, tx.signSegWitv0(0, commitScript, privB, value));
@@ -567,10 +667,13 @@ describe("TxBuilder", () => {
         it("spends P2PKH to P2SH-P2WPKH", () => {
             const tx = new TxBuilder();
             tx.addInput("6f39db0a1892c8ac9201143f8d5dc4fd39976e38eef29cdc67108bfce97b0810:0");
-            tx.addOutput(49.9998, Script.p2shLock(Script.p2wpkhLock(pubkeyB)));
+            tx.addOutput(49.9998, Script.p2shLock(Script.p2wpkhLock(pubkeyB.toBuffer())));
             tx.setScriptSig(
                 0,
-                Script.p2pkhUnlock(tx.sign(0, Script.p2pkhLock(pubkeyA), privA), pubkeyA),
+                Script.p2pkhUnlock(
+                    tx.sign(0, Script.p2pkhLock(pubkeyA.toBuffer()), privA),
+                    pubkeyA.toBuffer(),
+                ),
             );
 
             expect(tx.serialize().toString("hex")).to.equal(
@@ -581,13 +684,18 @@ describe("TxBuilder", () => {
         it("spends P2SH-P2WPKH to P2WPKH", () => {
             const tx = new TxBuilder();
             tx.addInput("a21e120c7d256e21a40f82ff24000d6d9823a28c7f573190b11727caa9e0428a:0");
-            tx.addOutput(49.9997, Script.p2wpkhLock(pubkeyB));
-            tx.setScriptSig(0, Script.p2shUnlock(Script.p2wpkhLock(pubkeyB))); // redeem script for p2sh
+            tx.addOutput(49.9997, Script.p2wpkhLock(pubkeyB.toBuffer()));
+            tx.setScriptSig(0, Script.p2shUnlock(Script.p2wpkhLock(pubkeyB.toBuffer()))); // redeem script for p2sh
             tx.addWitness(
                 0,
-                tx.signSegWitv0(0, Script.p2pkhLock(pubkeyB), privB, Value.fromBitcoin(49.9998)),
+                tx.signSegWitv0(
+                    0,
+                    Script.p2pkhLock(pubkeyB.toBuffer()),
+                    privB,
+                    Value.fromBitcoin(49.9998),
+                ),
             );
-            tx.addWitness(0, pubkeyB);
+            tx.addWitness(0, pubkeyB.toBuffer());
 
             expect(tx.serialize().toString("hex")).to.equal(
                 "020000000001018a42e0a9ca2717b19031577f8ca223986d0d0024ff820fa4216e257d0c121ea20000000017160014c538c517797dfefdf30142dc1684bfd947532dbbffffffff01d07c052a01000000160014c538c517797dfefdf30142dc1684bfd947532dbb02483045022100dffb1e407f8b8545fd79d27de887a3152a611cef99952eb56ddf3795b3bdbf25022021904ce657abfa85004a94a8aee1b59997dae5ad4401ba926d476df6f35e890a01210334acee9adf0e3e490a422dfe98bc10a8091b43047b793b8d840657b6b6a46c56ffffffff",
@@ -595,17 +703,29 @@ describe("TxBuilder", () => {
         });
 
         it("BIP 143 P2SH-P2WPKH Test Vector", () => {
-            const pubkey = Buffer.from("03ad1d8e89212f0b92c74d23bb710c00662ad1470198ac48c43f7d6f93a2a26873", "hex"); // prettier-ignore
-            const privkey = Buffer.from("eb696a065ef48a2192da5b28b694f87544b30fae8327c4510137a922f32c6dcf", "hex"); // prettier-ignore
+            const pubkey = new PublicKey(
+                Buffer.from(
+                    "03ad1d8e89212f0b92c74d23bb710c00662ad1470198ac48c43f7d6f93a2a26873",
+                    "hex",
+                ),
+                Network.mainnet,
+            );
+            const privkey = new PrivateKey(
+                Buffer.from(
+                    "eb696a065ef48a2192da5b28b694f87544b30fae8327c4510137a922f32c6dcf",
+                    "hex",
+                ),
+                Network.mainnet,
+            );
             const tx = new TxBuilder();
             tx.version = 1;
             tx.addInput(TxIn.fromHex("db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a54770100000000feffffff")); // prettier-ignore
             tx.addOutput(TxOut.fromHex("b8b4eb0b000000001976a914a457b684d7f0d539a46a45bbc043f35b59d0d96388ac")); // prettier-ignore
             tx.addOutput(TxOut.fromHex("0008af2f000000001976a914fd270b1ee6abcaea97fea7ad0402e8bd8ad6d77c88ac")); // prettier-ignore
             tx.setLockTime(LockTime.parse(StreamReader.fromHex("92040000")));
-            tx.setScriptSig(0, Script.p2shUnlock(Script.p2wpkhLock(pubkey)));
-            tx.addWitness(0, tx.signSegWitv0(0, Script.p2pkhLock(pubkey), privkey, 10));
-            tx.addWitness(0, pubkey);
+            tx.setScriptSig(0, Script.p2shUnlock(Script.p2wpkhLock(pubkey.toBuffer())));
+            tx.addWitness(0, tx.signSegWitv0(0, Script.p2pkhLock(pubkey.toBuffer()), privkey, 10));
+            tx.addWitness(0, pubkey.toBuffer());
 
             expect(tx.serialize().toString("hex")).to.equal(
                 "01000000000101db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a5477010000001716001479091972186c449eb1ded22b78e40d009bdf0089feffffff02b8b4eb0b000000001976a914a457b684d7f0d539a46a45bbc043f35b59d0d96388ac0008af2f000000001976a914fd270b1ee6abcaea97fea7ad0402e8bd8ad6d77c88ac02473044022047ac8e878352d3ebbde1c94ce3a10d057c24175747116f8288e5d794d12d482f0220217f36a485cae903c713331d877c1f64677e3622ad4010726870540656fe9dcb012103ad1d8e89212f0b92c74d23bb710c00662ad1470198ac48c43f7d6f93a2a2687392040000",
@@ -617,11 +737,16 @@ describe("TxBuilder", () => {
             tx.addInput("d9a81605b0ecb6df24812333194df07584ed32c4c5717c6b448c458114090fa4:0");
             tx.addOutput(
                 49.9999,
-                Script.p2shLock(Script.p2wshLock(Script.p2msLock(2, pubkeyA, pubkeyB))),
+                Script.p2shLock(
+                    Script.p2wshLock(Script.p2msLock(2, pubkeyA.toBuffer(), pubkeyB.toBuffer())),
+                ),
             );
             tx.setScriptSig(
                 0,
-                Script.p2pkhUnlock(tx.sign(0, Script.p2pkhLock(pubkeyA), privA), pubkeyA),
+                Script.p2pkhUnlock(
+                    tx.sign(0, Script.p2pkhLock(pubkeyA.toBuffer()), privA),
+                    pubkeyA.toBuffer(),
+                ),
             );
 
             expect(tx.serialize().toString("hex")).to.equal(
@@ -632,11 +757,11 @@ describe("TxBuilder", () => {
         it("spends P2SH-P2WSH-P2MS to P2WPKH", () => {
             const tx = new TxBuilder();
             tx.addInput("b2118a5883bd69ad9e4812105874a8725cb80dd5c2df899bb218371bbf07ae7d:0");
-            tx.addOutput(49.9998, Script.p2wpkhLock(pubkeyB));
+            tx.addOutput(49.9998, Script.p2wpkhLock(pubkeyB.toBuffer()));
 
             // witnessScript is used to generate the sha256 in the witness program
             // witnessScript is also the commitScript for the signatures
-            const witnessScript = Script.p2msLock(2, pubkeyA, pubkeyB);
+            const witnessScript = Script.p2msLock(2, pubkeyA.toBuffer(), pubkeyB.toBuffer());
 
             // redeemScript is a P2WSH witness program hash sha256 hashes the witness Script
             const redeemScript = Script.p2wshLock(witnessScript);
@@ -671,7 +796,10 @@ describe("TxBuilder", () => {
             );
             tx.setScriptSig(
                 0,
-                Script.p2pkhUnlock(tx.sign(0, Script.p2pkhLock(pubkeyA), privA), pubkeyA),
+                Script.p2pkhUnlock(
+                    tx.sign(0, Script.p2pkhLock(pubkeyA.toBuffer()), privA),
+                    pubkeyA.toBuffer(),
+                ),
             );
 
             expect(tx.serialize().toString("hex")).to.equal(
@@ -682,7 +810,7 @@ describe("TxBuilder", () => {
         it("spends P2SH-P2WSH to P2WPKH", () => {
             const tx = new TxBuilder();
             tx.addInput("09a040b6126eb9a1cbf55ef2af28bbef063f219c59b25054d8d8542966a11051:0");
-            tx.addOutput(49.9998, Script.p2wpkhLock(pubkeyB));
+            tx.addOutput(49.9998, Script.p2wpkhLock(pubkeyB.toBuffer()));
 
             // witnessScript is used to generate the sha256 in the witness program
             // witnessScript is also the commitScript for the signatures

--- a/packages/bitcoin/lib/TxBuilder.ts
+++ b/packages/bitcoin/lib/TxBuilder.ts
@@ -3,6 +3,7 @@ import { hash256, sign, sigToDER } from "@node-lightning/crypto";
 import { BitcoinError, BitcoinErrorCode, Witness } from ".";
 import { LockTime } from "./LockTime";
 import { OutPoint } from "./OutPoint";
+import { PrivateKey } from "./PrivateKey";
 import { Script } from "./Script";
 import { Sequence } from "./Sequence";
 import { Tx } from "./Tx";
@@ -260,12 +261,12 @@ export class TxBuilder {
      * @param commitScript Script that is committed during signature
      * @param privateKey 32-byte private key
      */
-    public sign(input: number, commitScript: Script, privateKey: Buffer): Buffer {
+    public sign(input: number, commitScript: Script, privateKey: PrivateKey): Buffer {
         // create the hash of the transaction for the input
         const hash = this.hashLegacy(input, commitScript);
 
         // sign DER encode signature
-        const sig = sign(hash, privateKey);
+        const sig = sign(hash, privateKey.toBuffer());
         const der = sigToDER(sig);
 
         // return signature with 1-byte sighash type
@@ -286,14 +287,14 @@ export class TxBuilder {
     public signSegWitv0(
         input: number,
         commitScript: Script,
-        privateKey: Buffer,
+        privateKey: PrivateKey,
         value: number | Value,
     ): Buffer {
         // create the hash of the transaction for the input
         const hash = this.hashSegwitv0(input, commitScript, value);
 
         // sign DER encode signature
-        const sig = sign(hash, privateKey);
+        const sig = sign(hash, privateKey.toBuffer());
         const der = sigToDER(sig);
 
         // return signature with 1-byte sighash type

--- a/packages/bitcoin/lib/TxBuilder.ts
+++ b/packages/bitcoin/lib/TxBuilder.ts
@@ -1,5 +1,5 @@
 import { BufferWriter } from "@node-lightning/bufio";
-import { hash256, sign, sigToDER } from "@node-lightning/crypto";
+import { hash256, sign, sigToDER, validPrivateKey } from "@node-lightning/crypto";
 import { BitcoinError, BitcoinErrorCode, Witness } from ".";
 import { LockTime } from "./LockTime";
 import { OutPoint } from "./OutPoint";
@@ -261,12 +261,14 @@ export class TxBuilder {
      * @param commitScript Script that is committed during signature
      * @param privateKey 32-byte private key
      */
-    public sign(input: number, commitScript: Script, privateKey: PrivateKey): Buffer {
+    public sign(input: number, commitScript: Script, privateKey: PrivateKey | Buffer): Buffer {
+        const privateKeyBuffer = Buffer.isBuffer(privateKey) ? privateKey : privateKey.toBuffer();
+
         // create the hash of the transaction for the input
         const hash = this.hashLegacy(input, commitScript);
 
         // sign DER encode signature
-        const sig = sign(hash, privateKey.toBuffer());
+        const sig = sign(hash, privateKeyBuffer);
         const der = sigToDER(sig);
 
         // return signature with 1-byte sighash type
@@ -287,14 +289,16 @@ export class TxBuilder {
     public signSegWitv0(
         input: number,
         commitScript: Script,
-        privateKey: PrivateKey,
+        privateKey: PrivateKey | Buffer,
         value: number | Value,
     ): Buffer {
+        const privateKeyBuffer = Buffer.isBuffer(privateKey) ? privateKey : privateKey.toBuffer();
+
         // create the hash of the transaction for the input
         const hash = this.hashSegwitv0(input, commitScript, value);
 
         // sign DER encode signature
-        const sig = sign(hash, privateKey.toBuffer());
+        const sig = sign(hash, privateKeyBuffer);
         const der = sigToDER(sig);
 
         // return signature with 1-byte sighash type


### PR DESCRIPTION
Modifies sign and signSegwitv0 methods to accept PrivateKey instead of an unverified Buffer.

Closes #252 